### PR TITLE
HITType prototype set notification calls were erroring

### DIFF
--- a/model/hit_type.js
+++ b/model/hit_type.js
@@ -129,7 +129,7 @@ module.exports = function(conf) {
    * 
    */
   HITType.prototype.setNotification = function(notification, active, callback) {
-    setNotification(this.id, notification, active, callback);
+    ret.setNotification(this.id, notification, active, callback);
   };
   
   return ret;


### PR DESCRIPTION
The HITType prototype setNotification method was calling an undefined method. I believe the intention was to call the method defined above it, so that is what I did.
