### PR TITLE
added functionality to create HITs using HITLayouts

### DIFF
--- a/model/hit.js
+++ b/model/hit.js
@@ -114,7 +114,7 @@ module.exports = function(config) {
       , str;
     if (self.maxAssignments) options.MaxAssignments =  self.maxAssignments;
     if (self.requesterAnnotation) options.RequesterAnnotation =  self.requesterAnnotation;
-    console.log(options);
+    // console.log(options);
     for (var name in params) {
       str = 'HITLayoutParameter.'+count+'.Name';
       options[str] = name;


### PR DESCRIPTION
To provide a less technical user interface to generating HITs you can use the requester UI when collaborating on mturk project with non-coders. A properly formed HITLayout yields a LayoutID when clicking on the project name links at https://requestersandbox.mturk.com/create/projects/. These layouts can additionally be supplied parameters in the form of ${parameter}, and the added functions handle this. 
Functions the same as HIT.create(), but takes an additional third argument as a JSON object containing parameters and values as {name:value} pairs. 
