### PR TITLE
added HITLayoutId as options for creating HIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ The HIT Type defines a bunch of things about the HIT such as approval time, rewa
 
 ### Create a HIT
 
-Assumes you have `HITTypeId` (like the one created in the previous step) and some XML (`questionXML`) that is a [QuestionForm](http://docs.aws.amazon.com/AWSMechTurk/latest/AWSMturkAPI/ApiReference_QuestionFormDataStructureArticle.html) data structure, an [ExternalQuestion](http://docs.aws.amazon.com/AWSMechTurk/latest/AWSMturkAPI/ApiReference_ExternalQuestionArticle.html) data structure, or an [HTMLQuestion](http://docs.aws.amazon.com/AWSMechTurk/latest/AWSMturkAPI/ApiReference_HTMLQuestionArticle.html) data structure.
+Assumes you have `HITTypeId` (like the one created in the previous step) and some XML (`questionXML`) that is a [QuestionForm](http://docs.aws.amazon.com/AWSMechTurk/latest/AWSMturkAPI/ApiReference_QuestionFormDataStructureArticle.html) data structure, an [ExternalQuestion](http://docs.aws.amazon.com/AWSMechTurk/latest/AWSMturkAPI/ApiReference_ExternalQuestionArticle.html) data structure, an [HTMLQuestion](http://docs.aws.amazon.com/AWSMechTurk/latest/AWSMturkAPI/ApiReference_HTMLQuestionArticle.html) data structure, or a [HITLayoutId](http://docs.aws.amazon.com/AWSMechTurk/latest/AWSMturkAPI/ApiReference_HITLayoutArticle.html) with optional parameters.
+
+	Use XML:
 
 	var CreateHITOptions = {
 		'HITTypeId': HITTypeId
@@ -51,6 +53,17 @@ Assumes you have `HITTypeId` (like the one created in the previous step) and som
 		if (err) throw err;
 		console.log("Created HIT "+HITId);
 	});
+
+
+	Or use a Layout:
+
+	var LayoutOptions = {
+	    'HITTypeId': HITTypeId
+	    , 'HITLayoutId': layoutId
+	    , 'HITLayoutParameters': {
+	    	foo: 'bar'
+	    }
+	};
 
 
 ### Fetch Reviewalbe HITs


### PR DESCRIPTION
Added HITLayouts and HITLayoutParameters to createHIT(). Also updated README with corresponding information.

Layout made on requester page, used to test:
&lt;h1&gt;${param1}&lt;/h1&gt;
&lt;input name="${param2}" required="" type="text" /&gt;

Corresponding function call:
mturk.RegisterHITType(RegisterHITTypeOptions, function(err, HITTypeId){
    if (err) throw err;
    console.log("Registered HIT type "+HITTypeId);
        var CreateHITOptions = {
        'HITTypeId': HITTypeId
        , 'HITLayoutId': '2UYP8PJWKUDJBZ4G4VU920B6UVFJ8X'
        , 'LifetimeInSeconds': 60 \* 20  
        , 'HITLayoutParameters': {
            param1:'foo',
            param2:'bar'
        }
    };
    mturk.CreateHIT(CreateHITOptions, function(err, HITId){
        if (err) throw err;
        console.log("Created HIT "+HITId);
    });
});
